### PR TITLE
Update ESP8266 FQBN in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c
 env:
   global:
   - ARDUINO_VERSION=1.8.4
-  - BD=esp8266:esp8266:d1:CpuFrequency=80,FlashSize=4M3M
+  - BD=esp8266:esp8266:d1:xtal=80,eesz=4M3M
 before_install:
 - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_1.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :1 -ac -screen 0 1280x1024x16"
 - sleep 3


### PR DESCRIPTION
Some of the menu IDs for the ESP8266 boards were recently changed (https://github.com/esp8266/Arduino/issues/5572), which caused compilation in the Travis CI build to fail with "Invalid option for board" error.